### PR TITLE
Update Git Repo Url git to https

### DIFF
--- a/lua-resty-hmac-v1.0-1.rockspec
+++ b/lua-resty-hmac-v1.0-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-resty-hmac"
 version = "v1.0-1"
 
 source = {
-  url = "git://github.com/jamesmarlowe/lua-resty-hmac.git"
+  url = "https://github.com/jamesmarlowe/lua-resty-hmac.git"
 }
 
 description = {


### PR DESCRIPTION
Installing https://luarocks.org/s3-1.0-3.src.rock
Missing dependencies for s3 1.0-3:
   lua-resty-hmac (not installed)

s3 1.0-3 depends on lua-resty-hmac (not installed)
Installing https://luarocks.org/lua-resty-hmac-v1.0-1.rockspec
Cloning into 'lua-resty-hmac'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Error: Failed installing dependency: https://luarocks.org/lua-resty-hmac-v1.0-1.rockspec - Failed cloning git repository.