### PR TITLE
Changed source URL to an HTTPS endpoint

### DIFF
--- a/lua-resty-hmac-v1.0-1.rockspec
+++ b/lua-resty-hmac-v1.0-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-resty-hmac"
 version = "v1.0-1"
 
 source = {
-  url = "git://github.com/jamesmarlowe/lua-resty-hmac.git"
+  url = "https://github.com/jamesmarlowe/lua-resty-hmac.git"
 }
 
 description = {


### PR DESCRIPTION
This solves the issue where using an SSH endpoint we get "The unauthenticated git protocol on port 9418 is no longer supported." error.